### PR TITLE
Partially fix multi-line support of import statements

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -339,7 +339,6 @@ exports.Lexer = class Lexer
     indent = match[0]
 
     @seenFor = no
-    @seenImport = no
 
     size = indent.length - 1 - indent.lastIndexOf '\n'
     noNewlines = @unfinished()

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -109,6 +109,28 @@ test "multiline complex import", ->
 
   eq toJS(input), output
 
+# test "multiline simple import", ->
+#   input = """import {
+#       foo,
+#       bar as baz
+#     } from 'lib'"""
+#   output = """import {
+#       foo,
+#       bar as baz
+#     } from 'lib';"""
+#   eq toJS(input), output
+
+# test "multiline complex import", ->
+#   input = """import foo, {
+#       bar,
+#       baz as qux
+#     } from 'lib'"""
+#   output = """import foo, {
+#       bar,
+#       baz as qux
+#     } from 'lib';"""
+#   eq toJS(input), output
+
 
 # Export statements
 

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -91,27 +91,23 @@ test "import default member from a module as well as the entire module's content
   output = "import foo, * as bar from 'lib';\n\nfoo.fooMethod();\n\nbar.barMethod();"
   eq toJS(input), output
 
-# test "multiline simple import", ->
-#   input = """import {
-#       foo,
-#       bar as baz
-#     } from 'lib'"""
-#   output = """import {
-#       foo,
-#       bar as baz
-#     } from 'lib';"""
-#   eq toJS(input), output
+test "multiline simple import", ->
+  input = """import {
+    foo,
+    bar as baz
+  } from 'lib'"""
+  output = "import { foo, bar as baz } from 'lib';"
 
-# test "multiline complex import", ->
-#   input = """import foo, {
-#       bar,
-#       baz as qux
-#     } from 'lib'"""
-#   output = """import foo, {
-#       bar,
-#       baz as qux
-#     } from 'lib';"""
-#   eq toJS(input), output
+  eq toJS(input), output
+
+test "multiline complex import", ->
+  input = """import foo, {
+      bar,
+      baz as qux
+    } from 'lib'"""
+  output = "import foo, { bar, baz as qux } from 'lib';"
+
+  eq toJS(input), output
 
 
 # Export statements


### PR DESCRIPTION
The removed line in `lexer.coffee` caused the lexer to think the import
statement was over too soon. Removing it fixes the lexer & grammar part of
multi-line support.

However, for some reason the code generation in `nodes.coffee` seems to not
preserve whitespace (especially newlines). This is also why I changed the tests
to expect single-line output from multi-line input. Maybe someone else knows
what's going on here.
